### PR TITLE
Bug fix for subscription GUID detection in URIs

### DIFF
--- a/src/GuidCodeLensProvider.ts
+++ b/src/GuidCodeLensProvider.ts
@@ -25,6 +25,8 @@ export class GuidCodeLensProvider implements CodeLensProvider {
 
         const text = document.getText();
 
+        const seen = new Set<string>();
+
         if(this.options.enableCodelensesForGuids)
         {
             const regex = /(?<!\/)([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/g;
@@ -35,6 +37,13 @@ export class GuidCodeLensProvider implements CodeLensProvider {
                 if (!match) { break; }
 
                 const guid = match[0];
+                
+                if (!guid) { continue; }
+                
+                // de-dup logic
+                const key  = guid.toLowerCase();
+                if (seen.has(key)) { continue; }
+                seen.add(key);
 
                 const response = this.guidCache.getResolved(guid);
 
@@ -55,16 +64,21 @@ export class GuidCodeLensProvider implements CodeLensProvider {
 
         if(this.options.enableCodelensesForAzureSubscriptionIds)
         {
-            const regex = /subscriptions\/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})(?!\/)/g;
+            const regex = /subscriptions\/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/g;
             const unresolvedGuidsAzureSubscription = new Set<string>();
             while (true) {
                 const match = regex.exec(text);
 
                 if (!match) { break; }
 
-                const guid = match[0].split('/').at(1);
+                const guid = match[1];
 
                 if (!guid) { continue; }
+
+                // de-dup logic
+                const key  = guid.toLowerCase();
+                if (seen.has(key)) { continue; }
+                seen.add(key);
 
                 const response = this.guidCache.getResolved(guid);
 
@@ -86,16 +100,20 @@ export class GuidCodeLensProvider implements CodeLensProvider {
         if(this.options.enableCodelensesForAzureManagementGroupIds)
         {
             const regex = /managementGroups\/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/g;
-
             const unresolvedGuidsAzureManagementGroups = new Set<string>();
             while (true) {
                 const match = regex.exec(text);
 
                 if (!match) { break; }
 
-                const guid = match[0].split('/').at(1);
+                const guid = match[1];
 
                 if (!guid) { continue; }
+
+                // de-dup logic
+                const key  = guid.toLowerCase();
+                if (seen.has(key)) { continue; }
+                seen.add(key);
 
                 const response = this.guidCache.getResolved(guid);
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -102,9 +102,27 @@ suite('Extension Test Suite', () => {
                 ]
             },
             {
-                input: '/subscription/6e93d4c7-9006-4009-934e-64d5f25cf435',
+                input: '/subscriptions/6e93d4c7-9006-4009-934e-64d5f25cf435',
                 expected: [
                     '6e93d4c7-9006-4009-934e-64d5f25cf435'
+                ]
+            },
+            {
+                input: '/subscriptions/0793005f-3399-43e7-8a30-334872963f4c/resourceGroups/testgroup/',
+                expected: [
+                    '0793005f-3399-43e7-8a30-334872963f4c'
+                ]
+            },
+            {
+                input: '/managementGroups/26ad5d40-9047-4142-aaaf-61508e7e426f',
+                expected: [
+                    '26ad5d40-9047-4142-aaaf-61508e7e426f'
+                ]
+            },
+            {
+                input: '/managementGroups/c7d70608-e919-4d8c-98a8-8a397c9dbdcc/resourceGroups/testgroup/',
+                expected: [
+                    'c7d70608-e919-4d8c-98a8-8a397c9dbdcc'
                 ]
             },
         ];


### PR DESCRIPTION
- Fixed the regex used to detect subscription GUIDs in URIs like `subscriptions/[guid]/resourceGroups`
- Added de-dup logic for duplicate GUID entries detected by `GuidCodeLensProvider`
- Added and improved test coverage for Azure subscription and management group handling in `extension.test.ts`